### PR TITLE
Added source as a top-level string enum attribute to the Equalify schema

### DIFF
--- a/equalify-schema-app/equalify-schema.json
+++ b/equalify-schema-app/equalify-schema.json
@@ -3,6 +3,10 @@
   "title": "STREAM Schema",
   "type": "object",
   "properties": {
+    "source": {
+      "type": "string",
+      "enum": ["scan", "extension", "manual"]
+    },
     "urls": {
       "type": "array",
       "items": {
@@ -30,7 +34,7 @@
           },
           "type": { "type": "string", "enum": ["pass", "error", "violation"] }
         },
-        "required": ["message", "relatedTagIds", "relatedNodeIds", "type"] 
+        "required": ["message", "relatedTagIds", "relatedNodeIds", "type"]
       }
     },
     "tags": {
@@ -56,11 +60,11 @@
             "items": { "type": "string" }
           },
           "relatedUrlId": { "type": "integer" },
-          "equalified": { "type": "boolean" } 
+          "equalified": { "type": "boolean" }
         },
-        "required": ["nodeId", "html", "relatedUrlId", "equalified"] 
+        "required": ["nodeId", "html", "relatedUrlId", "equalified"]
       }
     }
   },
-  "required": ["messages", "tags", "nodes", "urls"] 
+  "required": ["messages", "tags", "nodes", "urls", "source"]
 }


### PR DESCRIPTION
During a discussion with Blake, we decided that the `source` attribute should be added to the Equalify schema. This will help us understand where the data is coming from. Possible sources currently include:
- `scan`: These originate from the Equalify Scan API
- `extension`: These originate from the Equalify Chrome Extension
- `manual`: This is manually added to the DB

We might extend the enum values in the future.

This will be particularly helpful the `equalify-api` effort, because we'd like to compare the results from `scan`-derived results to existing nodes to determine whether or not we "equalify" or "un-equalify" them.
