### PR TITLE
Update axe-core.js

### DIFF
--- a/equalify-schema-app/converters/axe-core.js
+++ b/equalify-schema-app/converters/axe-core.js
@@ -107,7 +107,7 @@ function convertAxeResultsToStream(axeResults) {
         processIssues(axeResults.results.violations, 'violation');
     }
     if (axeResults.results.incomplete) {
-        processIssues(axeResults.results.incomplete, 'error');
+        processIssues(axeResults.results.incomplete, 'warning');
     }
     if (axeResults.results.passes) {
         processIssues(axeResults.results.passes, 'pass');


### PR DESCRIPTION
'incomplete' results now given the the type 'warning' instead of 'error'